### PR TITLE
[twinspica] Add stale issue integration

### DIFF
--- a/.github/stale.yaml
+++ b/.github/stale.yaml
@@ -1,0 +1,15 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  Closing the stale issue automatically as there has been no recent activity.
+  Please file a new issue if the problem still persists.


### PR DESCRIPTION
This PR adds the stale issue integration. If an issue is not acted up for more than 60 days, then it is put up for deletion with grace period of 7 days.